### PR TITLE
Adding HYBRID/NONLOCAL keywords + a bug fix

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,6 +1,11 @@
 name: CI
 
-on: [push,pull_request]
+on:
+  push:
+    branches: [master]
+    tags:
+      - 'v*'
+  pull_request:
 
 jobs:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,11 +1,6 @@
 name: CI
 
-on:
-  push:
-    branches: [master,hybrid_nonlocal]
-    tags:
-      - 'v*'
-  pull_request:
+on: [push,pull_request]
 
 jobs:
 

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -2,7 +2,7 @@ name: CI
 
 on:
   push:
-    branches: [master]
+    branches: [master,hybrid_nonlocal]
     tags:
       - 'v*'
   pull_request:

--- a/aiida_crystal17/parsers/raw/inputd12_write.py
+++ b/aiida_crystal17/parsers/raw/inputd12_write.py
@@ -121,14 +121,9 @@ def _hamiltonian_block(outstr, indict, atom_props):
 
         xc = get_keys(indict, ["scf", "dft", "xc"], raise_error=True)
 
-        exact_exchange = None
-        if get_keys(indict, ["scf","dft","exact_exchange"], False):
-            exact_exchange = get_keys(indict, ["scf","dft","exact_exchange"])
+        exact_exchange = get_keys(indict, ["scf","dft","exact_exchange"], None)
+        non_local = get_keys(indict, ["scf","dft","non_local"], None)
         
-        non_local = None
-        if get_keys(indict, ["scf","dft","non_local"], False):
-            non_local = get_keys(indict, ["scf","dft","non_local"])
-
         if isinstance(xc, (tuple, list)):
             if len(xc) == 2:
                 outstr += "EXCHANGE\n"

--- a/aiida_crystal17/parsers/raw/inputd12_write.py
+++ b/aiida_crystal17/parsers/raw/inputd12_write.py
@@ -131,9 +131,9 @@ def _hamiltonian_block(outstr, indict, atom_props):
 
         if isinstance(xc, (tuple, list)):
             if len(xc) == 2:
-                outstr += "CORRELAT\n"
-                outstr += "{}\n".format(xc[0])
                 outstr += "EXCHANGE\n"
+                outstr += "{}\n".format(xc[0])
+                outstr += "CORRELAT\n"
                 outstr += "{}\n".format(xc[1])
                 if exact_exchange is not None:
                     outstr += "HYBRID\n"

--- a/aiida_crystal17/parsers/raw/inputd12_write.py
+++ b/aiida_crystal17/parsers/raw/inputd12_write.py
@@ -120,12 +120,27 @@ def _hamiltonian_block(outstr, indict, atom_props):
         outstr += "DFT\n"
 
         xc = get_keys(indict, ["scf", "dft", "xc"], raise_error=True)
+
+        exact_exchange = None
+        if get_keys(indict, ["scf","dft","exact_exchange"], False):
+            exact_exchange = get_keys(indict, ["scf","dft","exact_exchange"])
+        
+        non_local = None
+        if get_keys(indict, ["scf","dft","non_local"], False):
+            non_local = get_keys(indict, ["scf","dft","non_local"])
+
         if isinstance(xc, (tuple, list)):
             if len(xc) == 2:
                 outstr += "CORRELAT\n"
                 outstr += "{}\n".format(xc[0])
                 outstr += "EXCHANGE\n"
                 outstr += "{}\n".format(xc[1])
+                if exact_exchange is not None:
+                    outstr += "HYBRID\n"
+                    outstr += "{}\n".format(exact_exchange)
+                if non_local is not None:
+                    outstr += "NONLOCAL\n"
+                    outstr += "{} {}\n".format(non_local[0],non_local[1])
         else:
             outstr += format_value(indict, ["scf", "dft", "xc"])
 

--- a/aiida_crystal17/validation/schemas/inputd12.schema.json
+++ b/aiida_crystal17/validation/schemas/inputd12.schema.json
@@ -366,13 +366,26 @@
               ]
             },
             "exact_exchange": {
-              "description": "the (pruned) integration grid",
+              "description": "amount of exact Hartree-Fock exchange into the exchange functional",
               "type": "integer",
-              "minimum": 0
+              "minimum": 0,
+              "maximum": 100
             },
             "non_local": {
-              "description": "the (pruned) integration grid",
+              "description": "setting of non-local weighting parameters",
               "type": "array",
+              "items": [
+                {
+                  "description": "exchange weight of the non-local part of exchange",
+                  "type": "number",
+                  "minimum": 0
+                },
+                {
+                  "description": "weight of the non-local correlation",
+                  "type": "number",
+                  "minimum": 0
+                }
+              ],
               "minItems":2,
               "maxItems":2
             },

--- a/aiida_crystal17/validation/schemas/inputd12.schema.json
+++ b/aiida_crystal17/validation/schemas/inputd12.schema.json
@@ -365,6 +365,17 @@
                 "XXLGRID"
               ]
             },
+            "exact_exchange": {
+              "description": "the (pruned) integration grid",
+              "type": "integer",
+              "minimum": 0
+            },
+            "non_local": {
+              "description": "the (pruned) integration grid",
+              "type": "array",
+              "minItems":2,
+              "maxItems":2
+            },
             "grid_weights": {
               "description": "the  grid point weights of the integration grid",
               "type": "string",


### PR DESCRIPTION
This PR aims to address the issue #37 

During the testing I noticed that the order of `EXCHANGE` and `CORRELAT` is wrong and it is also fixed in this PR.

